### PR TITLE
Queue concurrency 1 to prevent CUDA OOM

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -1340,4 +1340,5 @@ demo = gr.TabbedInterface(
 """
 )
 
+demo.queue(concurrency_count=1)
 demo.launch()


### PR DESCRIPTION
Mandatory for me as I have a RTX 2070 (8Gb) and I get CUDA OOM if two users launch jobs at the same time.
I can also use multiple tabs and jobs will be queued.
You may not want it to be the default though.